### PR TITLE
Add toggle for IPv6

### DIFF
--- a/master-region/load-balancers.tf
+++ b/master-region/load-balancers.tf
@@ -171,7 +171,7 @@ resource "aws_lb" "master-pub-lb" {
 
   internal           = false
   load_balancer_type = "application"
-  ip_address_type    = "dualstack"
+  ip_address_type    = "${var.enable_ipv6 == true ? "dualstack" : "ipv4"}"
 
   subnets = ["${aws_subnet.master-subnet.*.id}"]
 
@@ -267,7 +267,7 @@ resource "aws_lb" "pub-slv-pub-lb" {
 
   internal           = false
   load_balancer_type = "application"
-  ip_address_type    = "dualstack"
+  ip_address_type    = "${var.enable_ipv6 == true ? "dualstack" : "ipv4"}"
 
   subnets = ["${aws_subnet.public-subnet.*.id}"]
 
@@ -359,7 +359,7 @@ resource "aws_lb" "pub-slv-prvt-lb" {
 
   internal           = false
   load_balancer_type = "application"
-  ip_address_type    = "dualstack"
+  ip_address_type    = "${var.enable_ipv6 == true ? "dualstack" : "ipv4"}"
 
   subnets = ["${aws_subnet.public-subnet.*.id}"]
 

--- a/master-region/networking.tf
+++ b/master-region/networking.tf
@@ -22,7 +22,7 @@ resource "aws_subnet" "master-subnet" {
   ipv6_cidr_block   = "${cidrsubnet(cidrsubnet(aws_vpc.master-region-vpc.ipv6_cidr_block, 5, 0), ceil(log(length(data.aws_availability_zones.available.names) * 2, 2)), count.index)}"
 
   map_public_ip_on_launch         = true
-  assign_ipv6_address_on_creation = true
+  assign_ipv6_address_on_creation = "${var.enable_ipv6}"
 
   tags {
     Name    = "dcos-master-subnet-${data.aws_availability_zones.available.names[count.index]}"
@@ -40,7 +40,7 @@ resource "aws_subnet" "public-subnet" {
   ipv6_cidr_block   = "${cidrsubnet(cidrsubnet(aws_vpc.master-region-vpc.ipv6_cidr_block, 5, 1), ceil(log(length(data.aws_availability_zones.available.names) * 2, 2)) , count.index)}"
 
   map_public_ip_on_launch         = true
-  assign_ipv6_address_on_creation = true
+  assign_ipv6_address_on_creation = "${var.enable_ipv6}"
 
   tags {
     Name    = "dcos-public-subnet-${data.aws_availability_zones.available.names[count.index]}"
@@ -58,7 +58,7 @@ resource "aws_subnet" "private-subnet" {
   ipv6_cidr_block   = "${cidrsubnet(cidrsubnet(aws_vpc.master-region-vpc.ipv6_cidr_block, 5, 2), ceil(log(length(data.aws_availability_zones.available.names) * 2, 2)), count.index)}"
 
   map_public_ip_on_launch         = false
-  assign_ipv6_address_on_creation = true
+  assign_ipv6_address_on_creation = "${var.enable_ipv6}"
 
   tags {
     Name    = "dcos-private-subnet-${data.aws_availability_zones.available.names[count.index]}"

--- a/master-region/variables.tf
+++ b/master-region/variables.tf
@@ -72,6 +72,13 @@ variable "operating_system_user" {
   default = "core"
 }
 
+variable "enable_ipv6" {
+  type = "string"
+  description = "Enable IPv6 addresses."
+
+  default = true
+}
+
 variable "ssl_certificate_arn" {
   type        = "string"
   description = "The SSL certificate arn used to secure the loadbalancers."


### PR DESCRIPTION
#### Description

This PR adds a toggle to enable IPv6 support, as some AWS instance types do not support IPv6.

#### Backwards compatibility
None.

#### Linked issues

None.
