### PR TITLE
add instance ip lists to output

### DIFF
--- a/master-region/outputs.tf
+++ b/master-region/outputs.tf
@@ -2,6 +2,10 @@ output "private-master-lb-dns" {
   value = "${aws_lb.master-prvt-lb.dns_name}"
 }
 
+output "bastion-ip" {
+  value = "${module.bootstrap-node.bastion-ip}"
+}
+
 output "bootstrap-ip" {
   value = "${module.bootstrap-node.bootstrap-ip}"
 }
@@ -16,4 +20,19 @@ output "number-of-masters" {
 
 output "exhibitor-bucket" {
   value = "${module.bootstrap-node.exhibitor-bucket}"
+}
+
+output "master-public-ip-list" {
+  value = ["${module.master-instances.master-public-ip-list}"]
+}
+
+output "public-slave-public-ip-list" {
+  value = ["${module.public-slave-instances.public-slave-public-ip-list}"]
+}
+
+output "private-slave-private-ip-list" {
+  value = [
+    "${module.private-slave-instances.private-slave-private-ip-list}",
+    "${module.private-gpu-slave-instances.private-slave-private-ip-list}",
+  ]
 }


### PR DESCRIPTION
#### Description

This PR adds the IP addresses needed to provision machines outside of the module.

#### Backwards compatibility

Compatible.

#### Linked issues

None.
