### PR TITLE
add vpc endpoint id to output

### DIFF
--- a/master-region/outputs.tf
+++ b/master-region/outputs.tf
@@ -36,3 +36,7 @@ output "private-slave-private-ip-list" {
     "${module.private-gpu-slave-instances.private-slave-private-ip-list}",
   ]
 }
+
+output "s3-vpce-id" {
+  value = "${aws_vpc_endpoint.private-s3-endpoint.id}"
+}


### PR DESCRIPTION
#### Description

This PR adds the S3 VPC Endpoint ID to the output so it can be used to allow access to buckets outside of this module.

#### Backwards compatibility

No issues.

#### Linked issues

None.
